### PR TITLE
Fix a bug in List@select()

### DIFF
--- a/Scripts/Core/Object/List/select().sk
+++ b/Scripts/Core/Object/List/select().sk
@@ -32,8 +32,10 @@
         [
         remove_at(idx)
         ]
-
-    idx++
+      else
+        [
+        idx++
+        ]
     ]
 
   this


### PR DESCRIPTION
**Bug:**
```
{3 5 9 11}.select[item.pow2?]
// expecting {}, but wrongly returning {5 11}
```
**Cause:**
```
not test(at(idx))
        [
        remove_at(idx)
        ]
idx++ // Here! idx should not be increased when current item just been removed
```
**Fix:** Only increase idx when test success
