### PR TITLE
Reject editor only properties for now

### DIFF
--- a/Generator/Source/SkookumScriptGenerator/Private/SkookumScriptGenerator.cpp
+++ b/Generator/Source/SkookumScriptGenerator/Private/SkookumScriptGenerator.cpp
@@ -1431,7 +1431,10 @@ bool FSkookumScriptGenerator::is_property_type_supported(UProperty * property_p)
     {
     return false;
     }
-
+  if (property_p->GetPropertyFlags() & CPF_EditorOnly)
+    {
+    return false;
+    }
   return (get_skookum_property_type(property_p) != SkTypeID_None);
   }
 


### PR DESCRIPTION
- Reject editor only properties for now ( might re-enabled if SkookumScript will support both editor and runtime binding in future)
- Without this fix, non-editor build will fail whenever editor-only properties get exported in binding code.