### PR TITLE
Use ToString instead of GetPlainNameString when changing asset name

### DIFF
--- a/Source/SkookumScriptEditor/Private/SkookumScriptEditor.cpp
+++ b/Source/SkookumScriptEditor/Private/SkookumScriptEditor.cpp
@@ -574,7 +574,7 @@ void FSkookumScriptEditor::on_asset_renamed(const FAssetData & asset_data, const
 
   if (!m_overlay_path.IsEmpty() && asset_data.AssetClass == s_blueprint_class_name)
     {
-    UBlueprint * blueprint_p = FindObjectChecked<UBlueprint>(ANY_PACKAGE, *asset_data.AssetName.GetPlainNameString());
+    UBlueprint * blueprint_p = FindObjectChecked<UBlueprint>(ANY_PACKAGE, *asset_data.AssetName.ToString());
     if (blueprint_p)
       {
       rename_class_script_files(blueprint_p->GeneratedClass, FPaths::GetBaseFilename(old_object_path));


### PR DESCRIPTION
Steps to reproduce the bug:
```
1. Create new actor blueprint: BP_TestActor_1
2. Try rename BP_TestActor_1
3. Editor crashed
```
Solution:

> Use FName::ToString instead of FName::GetPlainNameString to locate blueprint asset, since FName::GetPlainNameString returning "BP_TestActor" which is incorrect in this case.

