### PR TITLE
Add rotation conversion operators for Vector3/Vector4

### DIFF
--- a/Scripts/VectorMath/Object/Vector3/RotationAngles().sk
+++ b/Scripts/VectorMath/Object/Vector3/RotationAngles().sk
@@ -1,0 +1,16 @@
+//---------------------------------------------------------------------------------------
+// * Convert the vector to a rotation angle
+//
+// # Returns:
+//   new rotation angle
+//
+// # Examples:
+//   !rot : [vec1 - vec2].RotationAngles
+//   !rot : some_actor.actor_forward_vector.RotationAngles
+//   Vector3!xyz(0 1 1).RotationAngles
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+() RotationAngles
+

--- a/Scripts/VectorMath/Object/Vector4/RotationAngles().sk
+++ b/Scripts/VectorMath/Object/Vector4/RotationAngles().sk
@@ -1,0 +1,15 @@
+//---------------------------------------------------------------------------------------
+// * Convert the vector to a rotation angle
+//
+// # Returns:
+//   new rotation angle
+//
+// # Examples:
+//   !rot : [vec1 - vec2].RotationAngles
+//   Vector4!xyzw(1 0 1 1).RotationAngles
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+() RotationAngles
+

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
@@ -15,6 +15,7 @@
 #include "SkVector3.hpp"
 #include "SkRotation.hpp"
 #include "SkTransform.hpp"
+#include "SkRotationAngles.hpp"
 
 //=======================================================================================
 // Method Definitions
@@ -480,6 +481,19 @@ namespace SkVector3_Impl
       }
     }
 
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   Vector3@RotationAngles() RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_RotationAngles(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+	{
+	// Do nothing if result not desired
+	if (result_pp)
+	  {
+		const FRotator & rotation = scope_p->this_as<SkVector3>().Rotation();
+		*result_pp = SkRotationAngles::new_instance(rotation);
+	  }
+	}
+
   /*
   //---------------------------------------------------------------------------------------
   // # Skookum:   Vector3@angle(Vector3 vec) Real
@@ -565,6 +579,7 @@ namespace SkVector3_Impl
       { "length",           mthd_length },
       { "length_squared",   mthd_length_squared },
       { "near?",            mthd_nearQ },
+	  { "RotationAngles",   mthd_RotationAngles },
       //{ "angle",            mthd_angle },
       //{ "normalize",        mthd_normalize },
     };

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
@@ -490,7 +490,7 @@ namespace SkVector3_Impl
     if (result_pp)
       {
       const FRotator & rotation = scope_p->this_as<SkVector3>().Rotation();
-        *result_pp = SkRotationAngles::new_instance(rotation);
+      *result_pp = SkRotationAngles::new_instance(rotation);
       }
     }
 

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector3.cpp
@@ -485,14 +485,14 @@ namespace SkVector3_Impl
   // # Skookum:   Vector3@RotationAngles() RotationAngles
   // # Author(s): Zachary Burke
   static void mthd_RotationAngles(SkInvokedMethod * scope_p, SkInstance ** result_pp)
-	{
-	// Do nothing if result not desired
-	if (result_pp)
-	  {
-		const FRotator & rotation = scope_p->this_as<SkVector3>().Rotation();
-		*result_pp = SkRotationAngles::new_instance(rotation);
-	  }
-	}
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      const FRotator & rotation = scope_p->this_as<SkVector3>().Rotation();
+        *result_pp = SkRotationAngles::new_instance(rotation);
+      }
+    }
 
   /*
   //---------------------------------------------------------------------------------------
@@ -579,7 +579,7 @@ namespace SkVector3_Impl
       { "length",           mthd_length },
       { "length_squared",   mthd_length_squared },
       { "near?",            mthd_nearQ },
-	  { "RotationAngles",   mthd_RotationAngles },
+      { "RotationAngles",   mthd_RotationAngles },
       //{ "angle",            mthd_angle },
       //{ "normalize",        mthd_normalize },
     };

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector4.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector4.cpp
@@ -359,12 +359,12 @@ namespace SkVector4_Impl
   // # Author(s): Zachary Burke
   static void mthd_RotationAngles(SkInvokedMethod * scope_p, SkInstance ** result_pp)
     {
-	// Do nothing if result not desired
-	if (result_pp)
-	  {
-	  const FRotator & rotation = scope_p->this_as<SkVector4>().Rotation();
-	  *result_pp = SkRotationAngles::new_instance(rotation);
-	  }
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      const FRotator & rotation = scope_p->this_as<SkVector4>().Rotation();
+      *result_pp = SkRotationAngles::new_instance(rotation);
+      }
     }
 
   /*
@@ -517,7 +517,7 @@ namespace SkVector4_Impl
       { "set",              mthd_set },
       { "zero?",            mthd_zeroQ },
       { "zero",             mthd_zero },
-	  { "RotationAngles",   mthd_RotationAngles },
+      { "RotationAngles",   mthd_RotationAngles },
 
       //{ "distance",         mthd_distance },
       //{ "distance_squared", mthd_distance_squared },

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector4.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkVector4.cpp
@@ -13,6 +13,7 @@
 
 #include "../../SkookumScriptRuntimePrivatePCH.h"
 #include "SkVector4.hpp"
+#include "SkRotationAngles.hpp"
 
 //=======================================================================================
 // Method Definitions
@@ -353,6 +354,19 @@ namespace SkVector4_Impl
       }
     }
 
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   Vector4@RotationAngles() RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_RotationAngles(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+	// Do nothing if result not desired
+	if (result_pp)
+	  {
+	  const FRotator & rotation = scope_p->this_as<SkVector4>().Rotation();
+	  *result_pp = SkRotationAngles::new_instance(rotation);
+	  }
+    }
+
   /*
   //---------------------------------------------------------------------------------------
   // # Skookum:   Vector4@distance(Vector4 vec) Real
@@ -503,6 +517,7 @@ namespace SkVector4_Impl
       { "set",              mthd_set },
       { "zero?",            mthd_zeroQ },
       { "zero",             mthd_zero },
+	  { "RotationAngles",   mthd_RotationAngles },
 
       //{ "distance",         mthd_distance },
       //{ "distance_squared", mthd_distance_squared },


### PR DESCRIPTION
Add conversion operators for Vector3/4 that call through to the native `FVector3` `FVector4` conversion routine. A conversion routine doesn't exist for `FVector2` so it is omitted.