### PR TITLE
Fix LoadModuleChecked Assert in Shipping/Dev Builds

### DIFF
--- a/Source/SkookumScriptEditor/Private/SkookumScriptEditor.cpp
+++ b/Source/SkookumScriptEditor/Private/SkookumScriptEditor.cpp
@@ -116,11 +116,14 @@ void FSkookumScriptEditor::StartupModule()
     m_on_assets_deleted_handle        = FEditorDelegates::OnAssetsDeleted.AddRaw(this, &FSkookumScriptEditor::on_assets_deleted);
     m_on_asset_post_import_handle     = FEditorDelegates::OnAssetPostImport.AddRaw(this, &FSkookumScriptEditor::on_asset_post_import);
 
-    FAssetRegistryModule & asset_registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(AssetRegistryConstants::ModuleName);
-    m_on_asset_added_handle             = asset_registry.Get().OnAssetAdded().AddRaw(this, &FSkookumScriptEditor::on_asset_added);
-    m_on_asset_renamed_handle           = asset_registry.Get().OnAssetRenamed().AddRaw(this, &FSkookumScriptEditor::on_asset_renamed);
-    m_on_in_memory_asset_created_handle = asset_registry.Get().OnInMemoryAssetCreated().AddRaw(this, &FSkookumScriptEditor::on_in_memory_asset_created);
-    m_on_in_memory_asset_deleted_handle = asset_registry.Get().OnInMemoryAssetDeleted().AddRaw(this, &FSkookumScriptEditor::on_in_memory_asset_deleted);
+    FAssetRegistryModule* asset_registry = FModuleManager::GetModulePtr<FAssetRegistryModule>(AssetRegistryConstants::ModuleName);
+    if (asset_registry)
+      {
+      m_on_asset_added_handle = asset_registry->Get().OnAssetAdded().AddRaw(this, &FSkookumScriptEditor::on_asset_added);
+      m_on_asset_renamed_handle = asset_registry->Get().OnAssetRenamed().AddRaw(this, &FSkookumScriptEditor::on_asset_renamed);
+      m_on_in_memory_asset_created_handle = asset_registry->Get().OnInMemoryAssetCreated().AddRaw(this, &FSkookumScriptEditor::on_in_memory_asset_created);
+      m_on_in_memory_asset_deleted_handle = asset_registry->Get().OnInMemoryAssetDeleted().AddRaw(this, &FSkookumScriptEditor::on_in_memory_asset_deleted);
+      }
 
     // Instrument all already existing blueprints
     TArray<UObject*> blueprint_array;

--- a/Source/SkookumScriptRuntime/Private/SkookumScriptRuntime.cpp
+++ b/Source/SkookumScriptRuntime/Private/SkookumScriptRuntime.cpp
@@ -7,6 +7,8 @@
 // Author: Conan Reis
 //=======================================================================================
 
+#include "SkookumScriptRuntimePrivatePCH.h"
+
 #include "ISkookumScriptRuntime.h"
 #include "Bindings/SkUEBindings.hpp"
 #include "Bindings/SkUEClassBinding.hpp"
@@ -695,7 +697,7 @@ void FSkookumScriptRuntime::set_project_generated_bindings(SkUEBindingsInterface
 
   // Make sure the SkookumScriptEditor module is loaded at this point as it might need to update blueprint classes and recompile blueprints with errors
   #if WITH_EDITORONLY_DATA
-    FModuleManager::Get().LoadModuleChecked<IModuleInterface>("SkookumScriptEditor");
+    FModuleManager::GetModulePtr<IModuleInterface>("SkookumScriptEditor");
   #endif
 
   // Now that binaries are loaded, point to the bindings to use


### PR DESCRIPTION
I noticed that builds in 4.14 were broken. It was triggering [a check in FModuleManager](https://github.com/EpicGames/UnrealEngine/blob/55c9f3ba0010e2e483d49a4cd378f36a46601fad/Engine/Source/Runtime/Core/Private/Modules/ModuleManager.cpp#L378).

This patch fixes the builds by loading the modules differently, it seems to be what some other plugin folks are doing as well. I see there is also 1 other place where `LoadModuleChecked` is called (SkookumScriptEditorGUI.cpp), but as far as builds go, I don't think this would ever get called.

Shipping and Dev builds are working again for me.