### PR TITLE
Add missing operands for RotationAngles

### DIFF
--- a/Scripts/VectorMath/Object/RotationAngles/Vector3().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/Vector3().sk
@@ -1,0 +1,14 @@
+//---------------------------------------------------------------------------------------
+// Returns a new Vector3 that is the rotation as a unit vector facing in its direction.
+//
+// # Returns:
+//   new Vector3 that is a unit vector facing in the direction of the RotationAngles
+//
+// # Examples:
+//   rot1.Vector3
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+() Vector3
+

--- a/Scripts/VectorMath/Object/RotationAngles/add().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/add().sk
@@ -1,0 +1,18 @@
+//---------------------------------------------------------------------------------------
+// + Returns a new RotationAngles that is the sum of itself and the supplied RotationAngles.
+//
+// # Params:
+//   rot: RotationAngles to add
+//
+// # Returns:
+//   new RotationAngles that is the sum of itself and the supplied RotationAngles.
+//
+// # Examples:
+//   rot1 + rot2
+//   rot1.add(rot2)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/add_assign().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/add_assign().sk
@@ -1,0 +1,17 @@
+//---------------------------------------------------------------------------------------
+// += Adds supplied RotationAngles to itself
+//
+// # Params:
+//   rot: RotationAngles to add
+//
+// # Returns: itself
+//
+// # Examples:
+//   rot1 += rot2 
+//   rot1.add_assign(rot2)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/equal-Q().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/equal-Q().sk
@@ -1,0 +1,23 @@
+//---------------------------------------------------------------------------------------
+// Logical equality - same as = operator. Returns true if both objects are logically the
+// same - though they may be different objects.
+//
+// # Params:
+//   rot: RotationAngles to compare
+//
+// # Returns: true if equal false if not
+//
+// # Examples:
+//   obj1 = obj2
+//   obj1.equal?(obj2)
+//
+// # See:
+//   ~=  not_equal?()
+//   :=  assign()       - copies contents of one object to another
+//   :                  - bind operator - changes the object to which the variable refers
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) Boolean
+

--- a/Scripts/VectorMath/Object/RotationAngles/multiply().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/multiply().sk
@@ -1,0 +1,19 @@
+//---------------------------------------------------------------------------------------
+// * Returns a new value that is the product of itself and the supplied value.
+//
+// # Params:
+//   operand: amount to multiply each axis vaule by
+//
+// # Returns:
+//   new RotationAngles that is the product of this RotationAngles with each axis 
+//   multiplied by the supplied value.
+//
+// # Examples:
+//   rot2: rot1 * 3
+//   rot2: rot1.multiply(3)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(Real operand) RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/multiply_assign().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/multiply_assign().sk
@@ -1,0 +1,17 @@
+//---------------------------------------------------------------------------------------
+// *= Multiplies itself by supplied value
+//
+// # Params:
+//   operand: amount to multiply each axis value by
+//
+// # Returns: itself
+//
+// # Examples:
+//   rot *= 3
+//   rot.multiply_assign(3)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(Real operand) RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/negated().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/negated().sk
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------------------------
+// Method call for negation prefix operator '-' - ex: -rot
+// Returns the negated value of this RotationAngles - i.e. -this or 0 - this
+// The original RotationAngles remains unchanged.
+//
+// #Note
+//   Since this method is the alias for the negation prefix operator '-' it returns a new
+//   object rather than modifying the existing value.
+//   Methods often change the existing value/state of the object so that the instantiation
+//   operator ! or constructors can be used to create versions that return new objects.
+//   For that behaviour use negate() instead.
+//
+// #Examples
+//   do_stuff(-rot)
+//   do_stuff(rot.negated)
+//   -[rot * 5]
+//
+//   To negate the RotationAngles itself by modifying the existing value use:
+//     rot := -rot
+//     [or]
+//     rot := rot.negated
+//
+// #Author(s)  Zachary Burke
+//---------------------------------------------------------------------------------------
+
+() RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/not_equal-Q().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/not_equal-Q().sk
@@ -1,0 +1,23 @@
+//---------------------------------------------------------------------------------------
+// Logical inequality - same as ~= operator. Returns true if both objects are *not* 
+// logically the same.
+//
+// # Params:
+//   rot: RotationAngles to compare
+//
+// # Returns: true if *not* equal false if not
+//
+// # Examples:
+//   obj1 ~= obj2
+//   obj1.not_equal?(obj2)
+//
+// # See:
+//   =   equal?()
+//   :=  assign()       - copies contents of one object to another
+//   :                  - bind operator - changes the object to which the variable refers
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) Boolean
+

--- a/Scripts/VectorMath/Object/RotationAngles/subtract().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/subtract().sk
@@ -1,0 +1,18 @@
+//---------------------------------------------------------------------------------------
+// - Returns a new RotationAngles that is itself minus the supplied RotationAngles.
+//
+// # Params:
+//   rot: RotationAngles to subtract
+//
+// # Returns:
+//   new RotationAngles that is itself minus the supplied RotationAngles.
+//
+// # Examples:
+//   rot1 - rot2
+//   rot1.subtract(rot2)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) RotationAngles
+

--- a/Scripts/VectorMath/Object/RotationAngles/subtract_assign().sk
+++ b/Scripts/VectorMath/Object/RotationAngles/subtract_assign().sk
@@ -1,0 +1,17 @@
+//---------------------------------------------------------------------------------------
+// -= Subtracts supplied value from itself
+//
+// # Params:
+//   rot: RotationAngles to subtract
+//
+// # Returns: itself
+//
+// # Examples:
+//   rot1 -= rot2
+//   rot1.subtract_assign(rot2)
+//
+// # Author(s): Zachary Burke
+//---------------------------------------------------------------------------------------
+
+(RotationAngles rot) RotationAngles
+

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkRotationAngles.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkRotationAngles.cpp
@@ -173,7 +173,7 @@ namespace SkRotationAngles_Impl
     }
 
   //---------------------------------------------------------------------------------------
-  // # Skookum:   RotationAngles@*=(Real num) Vector3
+  // # Skookum:   RotationAngles@*=(Real num) RotationAngles
   // # Author(s): Zachary Burke
   static void mthd_op_multiply_assign(SkInvokedMethod * scope_p, SkInstance ** result_pp)
     {

--- a/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkRotationAngles.cpp
+++ b/Source/SkookumScriptRuntime/Private/Bindings/VectorMath/SkRotationAngles.cpp
@@ -26,6 +26,7 @@
 
 #include "SkRotationAngles.hpp"
 #include "SkRotation.hpp"
+#include "SkVector3.hpp"
 
 #include <SkookumScript/SkBoolean.hpp>
 #include <SkookumScript/SkReal.hpp>
@@ -74,6 +75,141 @@ namespace SkRotationAngles_Impl
       {
       const FRotator & rot = scope_p->this_as<SkRotationAngles>();
       *result_pp = SkRotation::new_instance(rot.Quaternion());
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@=(RotationAngles rot) Boolean
+  // # Author(s): Zachary Burke
+  static void mthd_op_equals(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkBoolean::new_instance(scope_p->this_as<SkRotationAngles>() == scope_p->get_arg<SkRotationAngles>(SkArg_1));
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@~=(RotationAngles rot) Boolean
+  // # Author(s): Zachary Burke
+  static void mthd_op_not_equal(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkBoolean::new_instance(scope_p->this_as<SkRotationAngles>() != scope_p->get_arg<SkRotationAngles>(SkArg_1));
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@+(RotationAngles rot) RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_add(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkRotationAngles::new_instance(scope_p->this_as<SkRotationAngles>() + scope_p->get_arg<SkRotationAngles>(SkArg_1));
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@+=(RotationAngles rot) RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_add_assign(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    SkInstance * this_p = scope_p->get_this();
+
+    this_p->as<SkRotationAngles>() += scope_p->get_arg<SkRotationAngles>(SkArg_1);
+
+    // Return this if result desired
+    if (result_pp)
+      {
+      this_p->reference();
+      *result_pp = this_p;
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@-(RotationAngles rot) RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_subtract(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkRotationAngles::new_instance(scope_p->this_as<SkRotationAngles>() - scope_p->get_arg<SkRotationAngles>(SkArg_1));
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@-=(RotationAngles rot) RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_subtract_assign(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    SkInstance * this_p = scope_p->get_this();
+
+    this_p->as<SkRotationAngles>() -= scope_p->get_arg<SkRotationAngles>(SkArg_1);
+
+    // Return this if result desired
+    if (result_pp)
+      {
+      this_p->reference();
+      *result_pp = this_p;
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@*(Real num) RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_multiply(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkRotationAngles::new_instance(scope_p->this_as<SkRotationAngles>() * scope_p->get_arg<SkReal>(SkArg_1));
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@*=(Real num) Vector3
+  // # Author(s): Zachary Burke
+  static void mthd_op_multiply_assign(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    SkInstance * this_p = scope_p->get_this();
+
+    this_p->as<SkRotationAngles>() *= scope_p->get_arg<SkReal>(SkArg_1);
+
+    // Return this if result desired
+    if (result_pp)
+      {
+      this_p->reference();
+      *result_pp = this_p;
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   -RotationAngles
+  // # Author(s): Zachary Burke
+  static void mthd_op_negated(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkRotationAngles::new_instance(-scope_p->this_as<SkRotationAngles>());
+      }
+    }
+
+  //---------------------------------------------------------------------------------------
+  // # Skookum:   RotationAngles@Vector3() Vector3
+  // # Author(s): Zachary Burke
+  static void mthd_Vector3(SkInvokedMethod * scope_p, SkInstance ** result_pp)
+    {
+    // Do nothing if result not desired
+    if (result_pp)
+      {
+      *result_pp = SkVector3::new_instance(scope_p->this_as<SkRotationAngles>().Vector());
       }
     }
 
@@ -139,6 +275,18 @@ namespace SkRotationAngles_Impl
       { "String",             mthd_String },
       { "Rotation",           mthd_Rotation },
 
+      { "equal?",             mthd_op_equals },
+      { "not_equal?",         mthd_op_not_equal },
+      { "add",                mthd_op_add },
+      { "add_assign",         mthd_op_add_assign },
+      { "subtract",           mthd_op_subtract },
+      { "subtract_assign",    mthd_op_subtract_assign },
+      { "multiply",           mthd_op_multiply },
+      { "multiply_assign",    mthd_op_multiply_assign },
+      { "negated",            mthd_op_negated },
+
+      { "Vector3",            mthd_Vector3 },
+      
       { "set",                mthd_set },
       { "zero?",              mthd_zeroQ },
       { "zero",               mthd_zero },


### PR DESCRIPTION
Brings available operands for RotationAngles up to parity with FRotator:
+
+=
-
-=
*
*=
=
~=
negate

Also added existing FRotator to Vector3 conversion for convenience.
